### PR TITLE
Fix type error in drillDatabase.ts

### DIFF
--- a/src/components/data/drillDatabase.ts
+++ b/src/components/data/drillDatabase.ts
@@ -30,8 +30,8 @@ export const DRILL_DATABASE: DrillDatabase = {
       name: 'Landing Spot Control',
       type: 'competitive',
       progressionLevels: [
-        { level: 1, distance: 10, targets: 1, attempts: 5, target: 3, description: '3/5 chips within 3 feet of target' },
-        { level: 2, distance: 20, targets: 2, attempts: 5, target: 3, description: '3/5 chips to alternating targets' }
+        { level: 1, distance: 10, target: 3, attempts: 5, description: '3/5 chips within 3 feet of target' },
+        { level: 2, distance: 20, target: 3, attempts: 5, description: '3/5 chips to alternating targets' }
       ],
       instructions: 'Place targets at specified distances, attempt to land chips within target zone',
       setupGuide: {


### PR DESCRIPTION
## Problem

The build was failing because of a type error in `src/components/data/drillDatabase.ts`. The error occurred because the chipping drill's progression levels were using a property called `targets` (plural) that doesn't exist in the `ProgressionLevel` type definition.

## Solution

This PR fixes the type error by removing the `targets` property from the chipping drill's progression levels. Since this property isn't defined in the `ProgressionLevel` type, it's not needed and was causing the build to fail.

This is a simple fix that should resolve the build error while maintaining the functionality of the application.

## Changes

- Removed the `targets` property from the chipping drill progression levels in `src/components/data/drillDatabase.ts`